### PR TITLE
Set javaEncoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.igniterealtime.openfire</groupId>
       <artifactId>openfire</artifactId>
-      <version>3.8.2</version>
+      <version>3.10</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -55,12 +55,15 @@
           <source>1.5</source>
           <target>1.5</target>
         </configuration>
-        <version>3.0</version>
+        <version>3.6.1</version>
       </plugin>
       <plugin>
         <groupId>com.reucon.maven.plugins</groupId>
         <artifactId>maven-openfire-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <javaEncoding>UTF-8</javaEncoding>
+        </configuration>
         <version>1.0.2-SNAPSHOT</version>
       </plugin>
     </plugins>


### PR DESCRIPTION
Configuration element <javaEncoding>UTF-8</javaEncoding> prevents NPE at build time

```
java.lang.NullPointerException: charsetName
	at java.io.OutputStreamWriter.<init>(OutputStreamWriter.java:99)
	at org.apache.jasper.compiler.JDTJavaCompiler.getJavaWriter(JDTJavaCompiler.java:120)
	at org.apache.jasper.compiler.Compiler.generateJava(Compiler.java:146)
	at org.apache.jasper.compiler.Compiler.compile(Compiler.java:362)
	at org.apache.jasper.JspC.processFile(JspC.java:1137)
	at org.apache.jasper.JspC.execute(JspC.java:1306)
	at com.reucon.maven.plugin.openfire.jspc.JspcMojo.compile(JspcMojo.java:279)
	at com.reucon.maven.plugin.openfire.jspc.JspcMojo.execute(JspcMojo.java:196)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)

```